### PR TITLE
Add HEAD request. #104

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -169,6 +169,9 @@ export default class Spark {
     try {
       const res = await this.#fetch(url, {
         method: 'HEAD',
+        headers: {
+          'Accept': 'application/vnd.ipld.raw'
+        },
         signal: AbortSignal.timeout(10_000)
       })
       stats.headStatusCode = res.status

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -170,7 +170,7 @@ export default class Spark {
       const res = await this.#fetch(url, {
         method: 'HEAD',
         headers: {
-          'Accept': 'application/vnd.ipld.raw'
+          Accept: 'application/vnd.ipld.raw'
         },
         signal: AbortSignal.timeout(10_000)
       })

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -230,11 +230,11 @@ export default class Spark {
         this.handleRunError(err)
       }
       const duration = Date.now() - started
-      const delay = /* calculateDelayBeforeNextTask({
+      const delay = calculateDelayBeforeNextTask({
         roundLengthInMs: APPROX_ROUND_LENGTH_IN_MS,
         maxTasksPerRound: this.#tasker.maxTasksPerRound,
         lastTaskDurationInMs: duration
-      }) */ 0
+      })
 
       if (delay > 0) {
         console.log(

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -78,6 +78,9 @@ export default class Spark {
     stats.providerAddress = provider.address
 
     await this.fetchCAR(provider.protocol, provider.address, retrieval.cid, stats)
+    if (stats.protocol === 'http') {
+      await this.testHeadRequest(provider.address, retrieval.cid, stats)
+    }
   }
 
   async fetchCAR (protocol, address, cid, stats) {
@@ -160,6 +163,22 @@ export default class Spark {
     stats.endAt = new Date()
   }
 
+  async testHeadRequest (address, cid, stats) {
+    const url = getRetrievalUrl('http', address, cid)
+    console.log(`Testing HEAD request: ${url}`)
+    try {
+      const res = await this.#fetch(url, {
+        method: 'HEAD',
+        signal: AbortSignal.timeout(10_000)
+      })
+      stats.headStatusCode = res.status
+    } catch (err) {
+      console.error(`Failed to make HEAD request to ${address} for ${cid}`)
+      console.error(err)
+      stats.headStatusCode = mapErrorToStatusCode(err)
+    }
+  }
+
   async submitMeasurement (task, stats) {
     console.log('Submitting measurement...')
     const payload = {
@@ -211,11 +230,11 @@ export default class Spark {
         this.handleRunError(err)
       }
       const duration = Date.now() - started
-      const delay = calculateDelayBeforeNextTask({
+      const delay = /* calculateDelayBeforeNextTask({
         roundLengthInMs: APPROX_ROUND_LENGTH_IN_MS,
         maxTasksPerRound: this.#tasker.maxTasksPerRound,
         lastTaskDurationInMs: duration
-      })
+      }) */ 0
 
       if (delay > 0) {
         console.log(
@@ -263,7 +282,8 @@ export function newStats () {
     carTooLarge: false,
     byteLength: 0,
     carChecksum: null,
-    statusCode: null
+    statusCode: null,
+    headStatusCode: null
   }
 }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -42,9 +42,9 @@ test('retrieval check for our CID', async () => {
   assertProp('protocol', 'http')
   assertProp('timeout', false)
   assertProp('statusCode', 200)
-  // FIXME - frisbii.fly.io doesn't support HEAD requests yet
+  // Note: frisbii.fly.io doesn't support HEAD requests yet
   // https://github.com/CheckerNetwork/frisbii-on-fly/issues/3
-  // assertProp('headStatusCode', 200)
+  assertProp('headStatusCode', 405)
   assertProp('byteLength', 200)
   assertProp('carTooLarge', false)
   // TODO - spark-api does not record this field yet

--- a/test/integration.js
+++ b/test/integration.js
@@ -42,6 +42,9 @@ test('retrieval check for our CID', async () => {
   assertProp('protocol', 'http')
   assertProp('timeout', false)
   assertProp('statusCode', 200)
+  // FIXME: Frisbii.fly.io doesn't support HEAD requests
+  // https://github.com/CheckerNetwork/frisbii-on-fly/issues/3
+  // assertProp('headStatusCode', 200)
   assertProp('byteLength', 200)
   assertProp('carTooLarge', false)
   // TODO - spark-api does not record this field yet

--- a/test/integration.js
+++ b/test/integration.js
@@ -42,7 +42,7 @@ test('retrieval check for our CID', async () => {
   assertProp('protocol', 'http')
   assertProp('timeout', false)
   assertProp('statusCode', 200)
-  // FIXME: Frisbii.fly.io doesn't support HEAD requests
+  // FIXME - frisbii.fly.io doesn't support HEAD requests yet
   // https://github.com/CheckerNetwork/frisbii-on-fly/issues/3
   // assertProp('headStatusCode', 200)
   assertProp('byteLength', 200)

--- a/test/spark.js
+++ b/test/spark.js
@@ -72,8 +72,8 @@ test('getRetrieval', async () => {
 test('testHeadRequest', async () => {
   const requests = []
   const spark = new Spark({
-    fetch: async (url, { method }) => {
-      requests.push({ url: url.toString(), method })
+    fetch: async (url, { method, headers }) => {
+      requests.push({ url: url.toString(), method, headers })
       return {
         status: 200
       }
@@ -82,7 +82,7 @@ test('testHeadRequest', async () => {
   const stats = {}
   await spark.testHeadRequest('/dns/frisbii.fly.dev/tcp/443/https', KNOWN_CID, stats)
   assertEquals(stats.headStatusCode, 200)
-  assertEquals(requests, [{ url: `https://frisbii.fly.dev/ipfs/${KNOWN_CID}?dag-scope=block`, method: 'HEAD' }])
+  assertEquals(requests, [{ url: `https://frisbii.fly.dev/ipfs/${KNOWN_CID}?dag-scope=block`, method: 'HEAD', headers: { Accept: 'application/vnd.ipld.raw' } }])
 })
 
 test('testHeadRequest - with statusCode=500', async () => {

--- a/test/spark.js
+++ b/test/spark.js
@@ -69,6 +69,52 @@ test('getRetrieval', async () => {
   ])
 })
 
+test('testHeadRequest', async () => {
+  const requests = []
+  const spark = new Spark({
+    fetch: async (url, { method }) => {
+      requests.push({ url: url.toString(), method })
+      return {
+        status: 200
+      }
+    }
+  })
+  const stats = {}
+  await spark.testHeadRequest('/dns/frisbii.fly.dev/tcp/443/https', KNOWN_CID, stats)
+  assertEquals(stats.headStatusCode, 200)
+  assertEquals(requests, [{ url: `https://frisbii.fly.dev/ipfs/${KNOWN_CID}?dag-scope=block`, method: 'HEAD' }])
+})
+
+test('testHeadRequest - with statusCode=500', async () => {
+  const requests = []
+  const spark = new Spark({
+    fetch: async (url, { method }) => {
+      requests.push({ url: url.toString(), method })
+      return {
+        status: 500
+      }
+    }
+  })
+  const stats = {}
+  await spark.testHeadRequest('/dns/frisbii.fly.dev/tcp/443/https', KNOWN_CID, stats)
+  assertEquals(stats.headStatusCode, 500)
+  assertEquals(requests, [{ url: `https://frisbii.fly.dev/ipfs/${KNOWN_CID}?dag-scope=block`, method: 'HEAD' }])
+})
+
+test('testHeadRequest - with network failure', async () => {
+  const requests = []
+  const spark = new Spark({
+    fetch: async (url, { method }) => {
+      requests.push({ url: url.toString(), method })
+      throw new Error()
+    }
+  })
+  const stats = {}
+  await spark.testHeadRequest('/dns/frisbii.fly.dev/tcp/443/https', KNOWN_CID, stats)
+  assertEquals(stats.headStatusCode, 600)
+  assertEquals(requests, [{ url: `https://frisbii.fly.dev/ipfs/${KNOWN_CID}?dag-scope=block`, method: 'HEAD' }])
+})
+
 test('fetchCAR - http', async () => {
   const requests = []
   const spark = new Spark({


### PR DESCRIPTION
For #104

Next: Integrate into spark-api. This is not blocking, as submitting the measurements also already works _with_ the new property -> https://github.com/CheckerNetwork/spark-api/pull/521