### PR TITLE
feat: support of `http-path` multiaddresses

### DIFF
--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -12,7 +12,9 @@ export function multiaddrToHttpUrl (addr) {
       // Remove leading slash and parse URI-encoded path
       // If the http-path is empty, both `.../http-path/` and `.../http-path` are valid.
       // See https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
-      path = decodeURIComponent(httpPathMultiAddr.replace(/^\/+/, ''))
+      path = httpPathMultiAddr === '/'
+        ? ''
+        : decodeURIComponent(httpPathMultiAddr)
     } catch (err) {
       throw Object.assign(
         new Error(`Cannot parse "${addr}": unsupported http path`, { cause: err }),

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -3,22 +3,25 @@
  * @returns {string} Parsed URI, e.g. `http://127.0.0.1:80`
  */
 export function multiaddrToHttpUrl (addr) {
-  const [multiAddr, httpPathMultiAddr] = addr.split('/http-path/')
+  const [multiAddr, httpPathMultiAddr] = addr.split('/http-path')
   const [, hostType, hostValue, ...multiAddrParts] = multiAddr.split('/')
-  let scheme, path, rest
-  if (httpPathMultiAddr) {
+  let scheme, path, rest, port
+  if (addr.includes('/http-path')) {
     scheme = multiAddrParts.shift()
     rest = multiAddrParts
-    path = decodeURIComponent(httpPathMultiAddr)
-    if (!path) {
+    try {
+      // Remove leading slash and parse URI-encoded path
+      // If the http-path is empty both `.../http-path/` and `.../http-path` are valid
+      path = decodeURIComponent(httpPathMultiAddr.replace(/^\/+/, ''))
+    } catch (err) {
       throw Object.assign(
-        new Error(`Cannot parse "${addr}": http-path is empty`),
-        { code: 'MULTIADDR_HAS_EMPTY_HTTP_PATH' }
+        new Error(`Cannot parse "${addr}": unsupported http path`, { cause: err }),
+        { code: 'UNSUPPORTED_HTTP_PATH' }
       )
     }
   } else {
     const ipProtocol = multiAddrParts.shift()
-    const port = multiAddrParts.shift()
+    port = multiAddrParts.shift()
     scheme = multiAddrParts.shift()
     rest = multiAddrParts
 
@@ -28,14 +31,6 @@ export function multiaddrToHttpUrl (addr) {
         { code: 'UNSUPPORTED_MULTIADDR_PROTO' }
       )
     }
-    path = getUriPort(scheme, port)
-  }
-
-  if (scheme !== 'http' && scheme !== 'https') {
-    throw Object.assign(
-      new Error(`Cannot parse "${addr}": unsupported scheme "${scheme}"`),
-      { code: 'UNSUPPORTED_MULTIADDR_SCHEME' }
-    )
   }
 
   if (rest.length) {
@@ -44,13 +39,18 @@ export function multiaddrToHttpUrl (addr) {
       { code: 'MULTIADDR_HAS_TOO_MANY_PARTS' }
     )
   }
+
   if (scheme !== 'http' && scheme !== 'https') {
     throw Object.assign(
       new Error(`Cannot parse "${addr}": unsupported scheme "${scheme}"`),
       { code: 'UNSUPPORTED_MULTIADDR_SCHEME' }
     )
   }
-  return `${scheme}://${getUriHost(hostType, hostValue)}${path}`
+
+  let url = `${scheme}://${getUriHost(hostType, hostValue)}`
+  if (port) url += getUriPort(scheme, port)
+  if (path) url += path
+  return url
 }
 
 function getUriHost (hostType, hostValue) {

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -12,8 +12,7 @@ export function multiaddrToHttpUrl (addr) {
       // Remove leading slash and parse URI-encoded path
       // If the http-path is empty, both `.../http-path/` and `.../http-path` are valid.
       // See https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
-      path = decodeURIComponent(httpPathMultiAddr.startsWith("/") ? httpPathMultiAddr.substring(1) : httpPathMultiAddr)
-      console.log("Path: ", path)
+      path = decodeURIComponent(httpPathMultiAddr.startsWith('/') ? httpPathMultiAddr.substring(1) : httpPathMultiAddr)
     } catch (err) {
       throw Object.assign(
         new Error(`Cannot parse "${addr}": unsupported http path`, { cause: err }),

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -11,7 +11,7 @@ export function multiaddrToHttpUrl (addr) {
     try {
       // Remove leading slash and parse URI-encoded path
       // See https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
-      path = decodeURIComponent(httpPathMultiAddr.startsWith('/') ? httpPathMultiAddr.substring(1) : httpPathMultiAddr)
+      path = decodeURIComponent(httpPathMultiAddr.substring(1))
     } catch (err) {
       throw Object.assign(
         new Error(`Cannot parse "${addr}": unsupported http path`, { cause: err }),

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -1,76 +1,56 @@
-import { multiaddr } from '@multiformats/multiaddr'
-
 /**
  * @param {string} addr Multiaddr, e.g. `/ip4/127.0.0.1/tcp/80/http`
  * @returns {string} Parsed URI, e.g. `http://127.0.0.1:80`
  */
 export function multiaddrToHttpUrl (addr) {
-  const multiaddress = multiaddr(addr)
-  const parts = multiaddress.stringTuples()
-  let httpProtocol = null
-  let ipProtocol = null
-  let host = null
-  let port = null
-  let path = ''
-  for (const [code, value] of parts) {
-    switch (code) {
-      case 4: // IPv4
-      case 41: // IPv6
-      case 53: // DNS
-      case 54: // DNS4
-      case 55: // DNS6
-      case 56: // DNSaddr
-        ipProtocol = deriveIpProtocol(code)
-        host = value
-        break
-      case 6: // TCP
-        port = value
-        break
-      case 480: // HTTP
-      case 443: // HTTPS
-        httpProtocol = deriveHttpProtocol(code)
-        break
-      case 481: // HTTP-Path
-        path = decodeURIComponent(value)
-        break
+  const [multiAddr, httpPathMultiAddr] = addr.split('/http-path/')
+  const [, hostType, hostValue, ...multiAddrParts] = multiAddr.split('/')
+  let scheme, path, rest
+  if (httpPathMultiAddr) {
+    scheme = multiAddrParts.shift()
+    rest = multiAddrParts
+    path = decodeURIComponent(httpPathMultiAddr)
+    if (!path) {
+      throw Object.assign(
+        new Error(`Cannot parse "${addr}": http-path is empty`),
+        { code: 'MULTIADDR_HAS_EMPTY_HTTP_PATH' }
+      )
     }
+  } else {
+    const ipProtocol = multiAddrParts.shift()
+    const port = multiAddrParts.shift()
+    scheme = multiAddrParts.shift()
+    rest = multiAddrParts
+
+    if (ipProtocol !== 'tcp') {
+      throw Object.assign(
+        new Error(`Cannot parse "${addr}": unsupported protocol "${ipProtocol}"`),
+        { code: 'UNSUPPORTED_MULTIADDR_PROTO' }
+      )
+    }
+    path = getUriPort(scheme, port)
   }
-  if (!ipProtocol || !host || !httpProtocol) {
+
+  if (scheme !== 'http' && scheme !== 'https') {
     throw Object.assign(
-      new Error(`Cannot parse "${addr}": missing ipProtocol or host or httpProtocol`),
-      { code: 'MULTIADDR_MISSING_PROTOCOL_OR_HOST' })
-  }
-  const hostString = getUriHost(ipProtocol, host)
-  const portString = getUriPort(httpProtocol, port)
-  return `${httpProtocol}://${hostString}${portString}${path}`
-}
-
-function deriveIpProtocol (code) {
-  switch (code) {
-    case 4: return 'ip4'
-    case 41: return 'ip6'
-    case 53: return 'dns'
-    case 54: return 'dns4'
-    case 55: return 'dns6'
-    case 56: return 'dnsaddr'
+      new Error(`Cannot parse "${addr}": unsupported scheme "${scheme}"`),
+      { code: 'UNSUPPORTED_MULTIADDR_SCHEME' }
+    )
   }
 
-  throw Object.assign(
-    new Error(`Unsupported multiaddr protocol code "${code}"`),
-    { code: 'UNSUPPORTED_MULTIADDR_PROTOCOL_CODE' }
-  )
-}
-
-function deriveHttpProtocol (code) {
-  switch (code) {
-    case 480: return 'http'
-    case 443: return 'https'
+  if (rest.length) {
+    throw Object.assign(
+      new Error(`Cannot parse "${addr}": too many parts`),
+      { code: 'MULTIADDR_HAS_TOO_MANY_PARTS' }
+    )
   }
-
-  throw Object.assign(
-    new Error(`Unsupported multiaddr protocol code "${code}"`),
-    { code: 'UNSUPPORTED_MULTIADDR_PROTOCOL_CODE' }
-  )
+  if (scheme !== 'http' && scheme !== 'https') {
+    throw Object.assign(
+      new Error(`Cannot parse "${addr}": unsupported scheme "${scheme}"`),
+      { code: 'UNSUPPORTED_MULTIADDR_SCHEME' }
+    )
+  }
+  return `${scheme}://${getUriHost(hostType, hostValue)}${path}`
 }
 
 function getUriHost (hostType, hostValue) {

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -20,10 +20,8 @@ export function multiaddrToHttpUrl (addr) {
       )
     }
   } else {
-    const ipProtocol = multiAddrParts.shift()
-    port = multiAddrParts.shift()
-    scheme = multiAddrParts.shift()
-    rest = multiAddrParts
+    let ipProtocol
+    ;[ipProtocol, port, scheme, ...rest] = multiAddrParts
 
     if (ipProtocol !== 'tcp') {
       throw Object.assign(

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -12,9 +12,8 @@ export function multiaddrToHttpUrl (addr) {
       // Remove leading slash and parse URI-encoded path
       // If the http-path is empty, both `.../http-path/` and `.../http-path` are valid.
       // See https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
-      path = httpPathMultiAddr === '/'
-        ? ''
-        : decodeURIComponent(httpPathMultiAddr)
+      path = decodeURIComponent(httpPathMultiAddr.startsWith("/") ? httpPathMultiAddr.substring(1) : httpPathMultiAddr)
+      console.log("Path: ", path)
     } catch (err) {
       throw Object.assign(
         new Error(`Cannot parse "${addr}": unsupported http path`, { cause: err }),

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -7,8 +7,7 @@ export function multiaddrToHttpUrl (addr) {
   const [, hostType, hostValue, ...multiAddrParts] = multiAddr.split('/')
   let scheme, path, rest, port
   if (addr.includes('/http-path')) {
-    scheme = multiAddrParts.shift()
-    rest = multiAddrParts
+    [scheme, ...rest] = multiAddrParts
     try {
       // Remove leading slash and parse URI-encoded path
       // If the http-path is empty, both `.../http-path/` and `.../http-path` are valid.

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -10,7 +10,6 @@ export function multiaddrToHttpUrl (addr) {
     [scheme, ...rest] = multiAddrParts
     try {
       // Remove leading slash and parse URI-encoded path
-      // If the http-path is empty, both `.../http-path/` and `.../http-path` are valid.
       // See https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
       path = decodeURIComponent(httpPathMultiAddr.startsWith('/') ? httpPathMultiAddr.substring(1) : httpPathMultiAddr)
     } catch (err) {

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -11,12 +11,12 @@ export function multiaddrToHttpUrl (addr) {
     rest = multiAddrParts
     try {
       // Remove leading slash and parse URI-encoded path
-      // If the http-path is empty both `.../http-path/` and `.../http-path` are valid
+      // If the http-path is empty both `.../http-path/` and `.../http-path` are valid, see https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
       path = decodeURIComponent(httpPathMultiAddr.replace(/^\/+/, ''))
     } catch (err) {
       throw Object.assign(
         new Error(`Cannot parse "${addr}": unsupported http path`, { cause: err }),
-        { code: 'UNSUPPORTED_HTTP_PATH' }
+        { code: 'INVALID_HTTP_PATH' }
       )
     }
   } else {
@@ -33,17 +33,17 @@ export function multiaddrToHttpUrl (addr) {
     }
   }
 
-  if (rest.length) {
-    throw Object.assign(
-      new Error(`Cannot parse "${addr}": too many parts`),
-      { code: 'MULTIADDR_HAS_TOO_MANY_PARTS' }
-    )
-  }
-
   if (scheme !== 'http' && scheme !== 'https') {
     throw Object.assign(
       new Error(`Cannot parse "${addr}": unsupported scheme "${scheme}"`),
       { code: 'UNSUPPORTED_MULTIADDR_SCHEME' }
+    )
+  }
+
+  if (rest.length) {
+    throw Object.assign(
+      new Error(`Cannot parse "${addr}": too many parts`),
+      { code: 'MULTIADDR_HAS_TOO_MANY_PARTS' }
     )
   }
 

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -11,7 +11,8 @@ export function multiaddrToHttpUrl (addr) {
     rest = multiAddrParts
     try {
       // Remove leading slash and parse URI-encoded path
-      // If the http-path is empty both `.../http-path/` and `.../http-path` are valid, see https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
+      // If the http-path is empty, both `.../http-path/` and `.../http-path` are valid.
+      // See https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
       path = decodeURIComponent(httpPathMultiAddr.replace(/^\/+/, ''))
     } catch (err) {
       throw Object.assign(

--- a/lib/multiaddr.js
+++ b/lib/multiaddr.js
@@ -1,32 +1,76 @@
+import { multiaddr } from '@multiformats/multiaddr'
+
 /**
  * @param {string} addr Multiaddr, e.g. `/ip4/127.0.0.1/tcp/80/http`
  * @returns {string} Parsed URI, e.g. `http://127.0.0.1:80`
  */
 export function multiaddrToHttpUrl (addr) {
-  const [, hostType, hostValue, ipProtocol, port, scheme, ...rest] = addr.split('/')
-
-  if (ipProtocol !== 'tcp') {
+  const multiaddress = multiaddr(addr)
+  const parts = multiaddress.stringTuples()
+  let httpProtocol = null
+  let ipProtocol = null
+  let host = null
+  let port = null
+  let path = ''
+  for (const [code, value] of parts) {
+    switch (code) {
+      case 4: // IPv4
+      case 41: // IPv6
+      case 53: // DNS
+      case 54: // DNS4
+      case 55: // DNS6
+      case 56: // DNSaddr
+        ipProtocol = deriveIpProtocol(code)
+        host = value
+        break
+      case 6: // TCP
+        port = value
+        break
+      case 480: // HTTP
+      case 443: // HTTPS
+        httpProtocol = deriveHttpProtocol(code)
+        break
+      case 481: // HTTP-Path
+        path = decodeURIComponent(value)
+        break
+    }
+  }
+  if (!ipProtocol || !host || !httpProtocol) {
     throw Object.assign(
-      new Error(`Cannot parse "${addr}": unsupported protocol "${ipProtocol}"`),
-      { code: 'UNSUPPORTED_MULTIADDR_PROTO' }
-    )
+      new Error(`Cannot parse "${addr}": missing ipProtocol or host or httpProtocol`),
+      { code: 'MULTIADDR_MISSING_PROTOCOL_OR_HOST' })
+  }
+  const hostString = getUriHost(ipProtocol, host)
+  const portString = getUriPort(httpProtocol, port)
+  return `${httpProtocol}://${hostString}${portString}${path}`
+}
+
+function deriveIpProtocol (code) {
+  switch (code) {
+    case 4: return 'ip4'
+    case 41: return 'ip6'
+    case 53: return 'dns'
+    case 54: return 'dns4'
+    case 55: return 'dns6'
+    case 56: return 'dnsaddr'
   }
 
-  if (scheme !== 'http' && scheme !== 'https') {
-    throw Object.assign(
-      new Error(`Cannot parse "${addr}": unsupported scheme "${scheme}"`),
-      { code: 'UNSUPPORTED_MULTIADDR_SCHEME' }
-    )
+  throw Object.assign(
+    new Error(`Unsupported multiaddr protocol code "${code}"`),
+    { code: 'UNSUPPORTED_MULTIADDR_PROTOCOL_CODE' }
+  )
+}
+
+function deriveHttpProtocol (code) {
+  switch (code) {
+    case 480: return 'http'
+    case 443: return 'https'
   }
 
-  if (rest.length) {
-    throw Object.assign(
-      new Error(`Cannot parse "${addr}": too many parts`),
-      { code: 'MULTIADDR_HAS_TOO_MANY_PARTS' }
-    )
-  }
-
-  return `${scheme}://${getUriHost(hostType, hostValue)}${getUriPort(scheme, port)}`
+  throw Object.assign(
+    new Error(`Unsupported multiaddr protocol code "${code}"`),
+    { code: 'UNSUPPORTED_MULTIADDR_PROTOCOL_CODE' }
+  )
 }
 
 function getUriHost (hostType, hostValue) {

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -318,7 +318,7 @@ function mapErrorToStatusCode (err) {
       return 703
     case 'MULTIADDR_HAS_TOO_MANY_PARTS':
       return 704
-    case 'UNSUPPORTED_HTTP_PATH':
+    case 'INVALID_HTTP_PATH':
       return 705
   }
 

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -318,6 +318,8 @@ function mapErrorToStatusCode (err) {
       return 703
     case 'MULTIADDR_HAS_TOO_MANY_PARTS':
       return 704
+    case 'UNSUPPORTED_HTTP_PATH':
+      return 705
   }
 
   // 9xx for content verification errors

--- a/test/multiaddr.test.js
+++ b/test/multiaddr.test.js
@@ -11,7 +11,8 @@ const HAPPY_CASES = [
   ['/dns4/meridian.space/tcp/8080/http', 'http://meridian.space:8080'],
   ['/dns6/meridian.space/tcp/8080/http', 'http://meridian.space:8080'],
   ['/dns/meridian.space/https/http-path/%2Fipni-provider%2FproviderID', 'https://meridian.space/ipni-provider/providerID'],
-  ['/dns/meridian.space/https/http-path/', 'https://meridian.space']
+  ['/dns/meridian.space/https/http-path/', 'https://meridian.space'],
+  ['/dns/meridian.space/https/http-path', 'https://meridian.space']
 ]
 
 for (const [multiaddr, expectedUri] of HAPPY_CASES) {

--- a/test/multiaddr.test.js
+++ b/test/multiaddr.test.js
@@ -9,7 +9,8 @@ const HAPPY_CASES = [
   ['/ip4/127.0.0.1/tcp/8080/https', 'https://127.0.0.1:8080'],
   ['/dns/meridian.space/tcp/8080/http', 'http://meridian.space:8080'],
   ['/dns4/meridian.space/tcp/8080/http', 'http://meridian.space:8080'],
-  ['/dns6/meridian.space/tcp/8080/http', 'http://meridian.space:8080']
+  ['/dns6/meridian.space/tcp/8080/http', 'http://meridian.space:8080'],
+  ['/dns/meridian.space/https/http-path/%2Fipni-provider%2F12D3KooWJ91c8xqshrNe7QAXPFAaeRr0Wq2UrgXGPf8UmMZMwyZ5', 'https://meridian.space/ipni-provider/12D3KooWJ91c8xqshrNe7QAXPFAaeRr0Wq2UrgXGPf8UmMZMwyZ5']
 ]
 
 for (const [multiaddr, expectedUri] of HAPPY_CASES) {

--- a/test/multiaddr.test.js
+++ b/test/multiaddr.test.js
@@ -26,6 +26,7 @@ const ERROR_CASES = [
   ['/ip4/127.0.0.1/tcp/80', 'Cannot parse "/ip4/127.0.0.1/tcp/80": unsupported scheme "undefined"'],
   ['/ip4/127.0.0.1/udp/90', 'Cannot parse "/ip4/127.0.0.1/udp/90": unsupported protocol "udp"'],
   ['/ip4/127.0.0.1/tcp/8080/http/p2p/pubkey', 'Cannot parse "/ip4/127.0.0.1/tcp/8080/http/p2p/pubkey": too many parts'],
+  // NOTE: This is a valid multiaddr value that we decided to not support yet.
   ['/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', 'Cannot parse "/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID": too many parts'],
   ['/dns/meridian.space/http/http-path/invalid%path', 'Cannot parse "/dns/meridian.space/http/http-path/invalid%path": unsupported http path']
 ]

--- a/test/multiaddr.test.js
+++ b/test/multiaddr.test.js
@@ -10,7 +10,8 @@ const HAPPY_CASES = [
   ['/dns/meridian.space/tcp/8080/http', 'http://meridian.space:8080'],
   ['/dns4/meridian.space/tcp/8080/http', 'http://meridian.space:8080'],
   ['/dns6/meridian.space/tcp/8080/http', 'http://meridian.space:8080'],
-  ['/dns/meridian.space/https/http-path/%2Fipni-provider%2F12D3KooWJ91c8xqshrNe7QAXPFAaeRr0Wq2UrgXGPf8UmMZMwyZ5', 'https://meridian.space/ipni-provider/12D3KooWJ91c8xqshrNe7QAXPFAaeRr0Wq2UrgXGPf8UmMZMwyZ5']
+  ['/dns/meridian.space/https/http-path/%2Fipni-provider%2FproviderID', 'https://meridian.space/ipni-provider/providerID'],
+  ['/dns/meridian.space/https/http-path/', 'https://meridian.space']
 ]
 
 for (const [multiaddr, expectedUri] of HAPPY_CASES) {
@@ -23,7 +24,9 @@ for (const [multiaddr, expectedUri] of HAPPY_CASES) {
 const ERROR_CASES = [
   ['/ip4/127.0.0.1/tcp/80', 'Cannot parse "/ip4/127.0.0.1/tcp/80": unsupported scheme "undefined"'],
   ['/ip4/127.0.0.1/udp/90', 'Cannot parse "/ip4/127.0.0.1/udp/90": unsupported protocol "udp"'],
-  ['/ip4/127.0.0.1/tcp/8080/http/p2p/pubkey', 'Cannot parse "/ip4/127.0.0.1/tcp/8080/http/p2p/pubkey": too many parts']
+  ['/ip4/127.0.0.1/tcp/8080/http/p2p/pubkey', 'Cannot parse "/ip4/127.0.0.1/tcp/8080/http/p2p/pubkey": too many parts'],
+  ['/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', 'Cannot parse "/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID": too many parts'],
+  ['/dns/meridian.space/http/http-path/invalid%path', 'Cannot parse "/dns/meridian.space/http/http-path/invalid%path": unsupported http path']
 ]
 
 for (const [multiaddr, expectedError] of ERROR_CASES) {

--- a/test/multiaddr.test.js
+++ b/test/multiaddr.test.js
@@ -27,7 +27,7 @@ const ERROR_CASES = [
   ['/ip4/127.0.0.1/udp/90', 'Cannot parse "/ip4/127.0.0.1/udp/90": unsupported protocol "udp"'],
   ['/ip4/127.0.0.1/tcp/8080/http/p2p/pubkey', 'Cannot parse "/ip4/127.0.0.1/tcp/8080/http/p2p/pubkey": too many parts'],
   // NOTE: This is a valid multiaddr value that we decided to not support yet.
-  ['/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', 'Cannot parse "/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID": too many parts'],
+  ['/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', 'Cannot parse "/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID": unsupported scheme "tcp"'],
   ['/dns/meridian.space/http/http-path/invalid%path', 'Cannot parse "/dns/meridian.space/http/http-path/invalid%path": unsupported http path']
 ]
 

--- a/test/spark.js
+++ b/test/spark.js
@@ -173,11 +173,11 @@ test('fetchCAR fails with statusCode=704 (multiaddr has too many parts) - multia
   assertEquals(stats.statusCode, 704, 'stats.statusCode')
 })
 
-test('fetchCAR fails with statusCode=704 (multiaddr has too many parts) - multiaddr with http-path', async () => {
+test('fetchCAR fails with statusCode=704 (scheme is not http/https) - multiaddr with http-path', async () => {
   const spark = new Spark()
   const stats = newStats()
   await spark.fetchCAR('http', '/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', KNOWN_CID, stats)
-  assertEquals(stats.statusCode, 704, 'stats.statusCode')
+  assertEquals(stats.statusCode, 703, 'stats.statusCode')
 })
 
 test('fetchCAR fails with statusCode=705 (multiaddr has invalid http-path)', async () => {

--- a/test/spark.js
+++ b/test/spark.js
@@ -165,12 +165,25 @@ test('fetchCAR fails with statusCode=703 (scheme is not http/https)', async () =
   await spark.fetchCAR('http', '/ip4/1.2.3.4/tcp/80/ldap', KNOWN_CID, stats)
   assertEquals(stats.statusCode, 703, 'stats.statusCode')
 })
-
-test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async () => {
+test('fetchCAR fails with statusCode=704 (multiaddr has too many parts) - multiaddr without http-path', async () => {
   const spark = new Spark()
   const stats = newStats()
   await spark.fetchCAR('http', '/ip4/1.2.3.4/tcp/80/http/p2p/pubkey', KNOWN_CID, stats)
   assertEquals(stats.statusCode, 704, 'stats.statusCode')
+})
+
+test('fetchCAR fails with statusCode=704 (multiaddr has too many parts) - multiaddr with http-path', async () => {
+  const spark = new Spark()
+  const stats = newStats()
+  await spark.fetchCAR('http', '/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', KNOWN_CID, stats)
+  assertEquals(stats.statusCode, 704, 'stats.statusCode')
+})
+
+test('fetchCAR fails with statusCode=705 (multiaddr has invalid http-path)', async () => {
+  const spark = new Spark()
+  const stats = newStats()
+  await spark.fetchCAR('http', '/dns/meridian.space/http/http-path/invalid%path', KNOWN_CID, stats)
+  assertEquals(stats.statusCode, 705, 'stats.statusCode')
 })
 
 test('fetchCAR fails with statusCode=801 (DNS error)', async () => {
@@ -192,20 +205,6 @@ test('fetchCAR fails with statusCode=802 (TCP connection refused)', async () => 
   const stats = newStats()
   await spark.fetchCAR('http', '/ip4/127.0.0.1/tcp/79/http', KNOWN_CID, stats)
   assertEquals(stats.statusCode, 802, 'stats.statusCode')
-})
-
-test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async () => {
-  const spark = new Spark()
-  const stats = newStats()
-  await spark.fetchCAR('http', '/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', KNOWN_CID, stats)
-  assertEquals(stats.statusCode, 704, 'stats.statusCode')
-})
-
-test('fetchCAR fails with statusCode=705 (multiaddr has unsupported http-path)', async () => {
-  const spark = new Spark()
-  const stats = newStats()
-  await spark.fetchCAR('http', '/dns/meridian.space/http/http-path/invalid%path', KNOWN_CID, stats)
-  assertEquals(stats.statusCode, 705, 'stats.statusCode')
 })
 
 // TODO:

--- a/test/spark.js
+++ b/test/spark.js
@@ -159,25 +159,25 @@ test('fetchCAR fails with statusCode=702 (protocol is not tcp)', async () => {
   assertEquals(stats.statusCode, 702, 'stats.statusCode')
 })
 
-test('fetchCAR fails with statusCode=703 (scheme is not http/https)', async () => {
+test('fetchCAR fails with statusCode=703 (scheme is not http/https) - multiaddr without http-path', async () => {
   const spark = new Spark()
   const stats = newStats()
   await spark.fetchCAR('http', '/ip4/1.2.3.4/tcp/80/ldap', KNOWN_CID, stats)
   assertEquals(stats.statusCode, 703, 'stats.statusCode')
 })
 
-test('fetchCAR fails with statusCode=704 (multiaddr has too many parts) - multiaddr without http-path', async () => {
-  const spark = new Spark()
-  const stats = newStats()
-  await spark.fetchCAR('http', '/ip4/1.2.3.4/tcp/80/http/p2p/pubkey', KNOWN_CID, stats)
-  assertEquals(stats.statusCode, 704, 'stats.statusCode')
-})
-
-test('fetchCAR fails with statusCode=704 (scheme is not http/https) - multiaddr with http-path', async () => {
+test('fetchCAR fails with statusCode=703 (scheme is not http/https) - multiaddr with http-path', async () => {
   const spark = new Spark()
   const stats = newStats()
   await spark.fetchCAR('http', '/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', KNOWN_CID, stats)
   assertEquals(stats.statusCode, 703, 'stats.statusCode')
+})
+
+test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async () => {
+  const spark = new Spark()
+  const stats = newStats()
+  await spark.fetchCAR('http', '/ip4/1.2.3.4/tcp/80/http/p2p/pubkey', KNOWN_CID, stats)
+  assertEquals(stats.statusCode, 704, 'stats.statusCode')
 })
 
 test('fetchCAR fails with statusCode=705 (multiaddr has invalid http-path)', async () => {

--- a/test/spark.js
+++ b/test/spark.js
@@ -194,6 +194,20 @@ test('fetchCAR fails with statusCode=802 (TCP connection refused)', async () => 
   assertEquals(stats.statusCode, 802, 'stats.statusCode')
 })
 
+test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async () => {
+  const spark = new Spark()
+  const stats = newStats()
+  await spark.fetchCAR('http', '/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', KNOWN_CID, stats)
+  assertEquals(stats.statusCode, 704, 'stats.statusCode')
+})
+
+test('fetchCAR fails with statusCode=705 (multiaddr has unsupported http-path)', async () => {
+  const spark = new Spark()
+  const stats = newStats()
+  await spark.fetchCAR('http', '/dns/meridian.space/http/http-path/invalid%path', KNOWN_CID, stats)
+  assertEquals(stats.statusCode, 705, 'stats.statusCode')
+})
+
 // TODO:
 // statusCode=901 - unsupported hash algorithm
 

--- a/test/spark.js
+++ b/test/spark.js
@@ -165,6 +165,7 @@ test('fetchCAR fails with statusCode=703 (scheme is not http/https)', async () =
   await spark.fetchCAR('http', '/ip4/1.2.3.4/tcp/80/ldap', KNOWN_CID, stats)
   assertEquals(stats.statusCode, 703, 'stats.statusCode')
 })
+
 test('fetchCAR fails with statusCode=704 (multiaddr has too many parts) - multiaddr without http-path', async () => {
   const spark = new Spark()
   const stats = newStats()

--- a/test/spark.js
+++ b/test/spark.js
@@ -166,7 +166,7 @@ test('fetchCAR fails with statusCode=703 (scheme is not http/https) - multiaddr 
   assertEquals(stats.statusCode, 703, 'stats.statusCode')
 })
 
-test('fetchCAR fails with statusCode=703 (scheme is not http/https) - multiaddr with http-path', async () => {
+test('fetchCAR fails with statusCode=703 (scheme is not supported) - multiaddr with http-path', async () => {
   const spark = new Spark()
   const stats = newStats()
   await spark.fetchCAR('http', '/dns/meridian.space/tcp/8080/http/http-path/%2Fipni-provider%2FproviderID', KNOWN_CID, stats)


### PR DESCRIPTION
**CHANGELOG**

1. Add support for `http-path` multi addresses in `multiaddrToHttpUrl`
2. Unit tests for `http-path` links
3. Integration tests for the error code induced by invalid `http-path` links

[Implementation Plan](https://github.com/CheckerNetwork/piece-indexer/issues/117#issuecomment-2672660743)
Subtask of:
https://github.com/CheckerNetwork/roadmap/issues/239
Related Issue:
https://github.com/CheckerNetwork/piece-indexer/issues/117