### PR TITLE
feat: add client-side max request duration timeout to Spark (#99)

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,4 @@
-export const SPARK_VERSION = '1.18.1'
+export const SPARK_VERSION = '1.18.2'
 export const MAX_CAR_SIZE = 200 * 1024 * 1024 // 200 MB
 export const APPROX_ROUND_LENGTH_IN_MS = 20 * 60_000 // 20 minutes
 export const MAX_JITTER_BETWEEN_TASKS_IN_MS = 10_000 // 10 seconds

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,3 +5,4 @@ export const MAX_JITTER_BETWEEN_TASKS_IN_MS = 10_000 // 10 seconds
 export const RPC_URL = 'https://api.node.glif.io/'
 export const RPC_AUTH = 'KZLIUb9ejreYOm-mZFM3UNADE0ux6CrHjxnS2D2Qgb8='
 export const MINER_TO_PEERID_CONTRACT_ADDRESS = '0x14183aD016Ddc83D638425D6328009aa390339Ce' // Contract address on the Filecoin EVM
+export const MAX_REQUEST_DURATION_MS = 90_000

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 export const SPARK_VERSION = '1.18.1'
 export const MAX_CAR_SIZE = 200 * 1024 * 1024 // 200 MB
 export const APPROX_ROUND_LENGTH_IN_MS = 20 * 60_000 // 20 minutes
+export const MAX_JITTER_BETWEEN_TASKS_IN_MS = 10_000 // 10 seconds
 export const RPC_URL = 'https://api.node.glif.io/'
 export const RPC_AUTH = 'KZLIUb9ejreYOm-mZFM3UNADE0ux6CrHjxnS2D2Qgb8='
 export const MINER_TO_PEERID_CONTRACT_ADDRESS = '0x14183aD016Ddc83D638425D6328009aa390339Ce' // Contract address on the Filecoin EVM

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -1,7 +1,7 @@
 /* global Zinnia */
 
 import { ActivityState } from './activity-state.js'
-import { SPARK_VERSION, MAX_CAR_SIZE, APPROX_ROUND_LENGTH_IN_MS } from './constants.js'
+import { SPARK_VERSION, MAX_CAR_SIZE, APPROX_ROUND_LENGTH_IN_MS, MAX_JITTER_BETWEEN_TASKS_IN_MS } from './constants.js'
 import { queryTheIndex } from './ipni-client.js'
 import { assertOkResponse } from './http-assertions.js'
 import { getIndexProviderPeerId as defaultGetIndexProvider } from './miner-info.js'
@@ -235,6 +235,7 @@ export default class Spark {
       const duration = Date.now() - started
       const delay = calculateDelayBeforeNextTask({
         roundLengthInMs: APPROX_ROUND_LENGTH_IN_MS,
+        maxJitterInMs: MAX_JITTER_BETWEEN_TASKS_IN_MS,
         maxTasksPerRound: this.#tasker.maxTasksPerRound,
         lastTaskDurationInMs: duration
       })
@@ -263,17 +264,24 @@ export default class Spark {
 /**
  * @param {object} args
  * @param {number} args.roundLengthInMs
+ * @param {number} [args.maxJitterInMs=0]
  * @param {number} args.maxTasksPerRound
  * @param {number} args.lastTaskDurationInMs
  */
 export function calculateDelayBeforeNextTask ({
   roundLengthInMs,
+  maxJitterInMs = 0,
   maxTasksPerRound,
   lastTaskDurationInMs
 }) {
   const baseDelay = roundLengthInMs / maxTasksPerRound
   const delay = baseDelay - lastTaskDurationInMs
-  return Math.min(delay, 60_000)
+  const base = Math.min(delay, 60_000)
+
+  // Introduce some jitter to avoid all clients querying cid.contact at the same time
+  const jitter = Math.round(Math.random() * maxJitterInMs)
+
+  return base + jitter
 }
 
 export function newStats () {

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -1,7 +1,7 @@
 /* global Zinnia */
 
 import { ActivityState } from './activity-state.js'
-import { SPARK_VERSION, MAX_CAR_SIZE, APPROX_ROUND_LENGTH_IN_MS, MAX_JITTER_BETWEEN_TASKS_IN_MS } from './constants.js'
+import { SPARK_VERSION, MAX_CAR_SIZE, APPROX_ROUND_LENGTH_IN_MS, MAX_JITTER_BETWEEN_TASKS_IN_MS, MAX_REQUEST_DURATION_MS } from './constants.js'
 import { queryTheIndex } from './ipni-client.js'
 import { assertOkResponse } from './http-assertions.js'
 import { getIndexProviderPeerId as defaultGetIndexProvider } from './miner-info.js'
@@ -83,20 +83,27 @@ export default class Spark {
     }
   }
 
-  async fetchCAR (protocol, address, cid, stats) {
+  async fetchCAR (protocol, address, cid, stats, { maxRequestDurationMs = MAX_REQUEST_DURATION_MS } = {}) {
     // Abort if no progress was made for 60 seconds
     const controller = new AbortController()
     const { signal } = controller
-    let timeout
+
+    let requestIdleTimeout
+    let maxDurationTimeout
+
     const resetTimeout = () => {
-      if (timeout) {
-        clearTimeout(timeout)
+      if (requestIdleTimeout) {
+        clearTimeout(requestIdleTimeout)
       }
-      timeout = setTimeout(() => {
+      requestIdleTimeout = setTimeout(() => {
         stats.timeout = true
         controller.abort()
       }, 60_000)
     }
+    maxDurationTimeout = setTimeout(() => {
+      stats.timeout = true
+      controller.abort()
+    }, maxRequestDurationMs)
 
     // WebCrypto API does not support streams yet, the hashing function requires entire data
     // to be provided at once. See https://github.com/w3c/webcrypto/issues/73
@@ -157,7 +164,8 @@ export default class Spark {
         stats.statusCode = mapErrorToStatusCode(err)
       }
     } finally {
-      clearTimeout(timeout)
+      clearTimeout(requestIdleTimeout)
+      clearTimeout(maxDurationTimeout)
     }
 
     stats.endAt = new Date()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "spark-checker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "spark-checker",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/test/spark.js
+++ b/test/spark.js
@@ -439,13 +439,13 @@ test('fetchCAR triggers timeout after long retrieval', async () => {
       })()
     }
   }
-  
+
   const spark = new Spark({ fetch })
   const stats = newStats()
-  
-  await spark.fetchCAR('http', '/dns/example.com/tcp/80/http', KNOWN_CID, stats, {
-  maxRequestDurationMs: 0
-})
 
-assertEquals(stats.timeout, true)
+  await spark.fetchCAR('http', '/dns/example.com/tcp/80/http', KNOWN_CID, stats, {
+    maxRequestDurationMs: 0
+  })
+
+  assertEquals(stats.timeout, true)
 })

--- a/test/spark.js
+++ b/test/spark.js
@@ -2,7 +2,7 @@
 
 import Spark, { calculateDelayBeforeNextTask, newStats } from '../lib/spark.js'
 import { test } from 'zinnia:test'
-import { assertInstanceOf, assertEquals, assertArrayIncludes } from 'zinnia:assert'
+import { assertInstanceOf, assertEquals, assertArrayIncludes, assertNotEquals, assertLessOrEqual, assertGreaterOrEqual } from 'zinnia:assert'
 import { SPARK_VERSION } from '../lib/constants.js'
 
 const KNOWN_CID = 'bafkreih25dih6ug3xtj73vswccw423b56ilrwmnos4cbwhrceudopdp5sq'
@@ -362,4 +362,61 @@ test('calculateDelayBeforeNextTask() handles one task per round', () => {
     lastTaskDurationInMs: 1_000
   })
   assertEquals(delay, 60_000)
+})
+
+test('calculateDelayBeforeNextTask() introduces random jitter', () => {
+  const getDelay = () => calculateDelayBeforeNextTask({
+    lastTaskDurationInMs: 3_000,
+
+    // one task every 10 seconds (on average)
+    roundLengthInMs: 60_000,
+    maxTasksPerRound: 6,
+
+    // jitter up to 1 second
+    maxJitterInMs: 1_000
+  })
+
+  const delay1 = getDelay()
+  const delay2 = getDelay()
+
+  assertGreaterOrEqual(delay1, 7_000)
+  assertLessOrEqual(delay1, 7_000 + 1_000)
+
+  assertNotEquals(
+    delay1,
+    delay2,
+    `Expected delay values to be different because of jitter. Actual value: ${delay1}`
+  )
+  assertLessOrEqual(
+    Math.abs(delay1 - delay2),
+    1_000,
+    `expected delay values to be within 1 second of each other. Actual values: ${delay1} <> ${delay2}`
+  )
+})
+
+test('calculateDelayBeforeNextTask() introduces random jitter for zero tasks in round', () => {
+  const getDelay = () => calculateDelayBeforeNextTask({
+    maxTasksPerRound: 0,
+
+    // jitter up to 1 second
+    maxJitterInMs: 1_000,
+
+    // the values below are not important
+    roundLengthInMs: 12345,
+    lastTaskDurationInMs: 12
+  })
+
+  const delay1 = getDelay()
+  const delay2 = getDelay()
+
+  assertNotEquals(
+    delay1,
+    delay2,
+    `Expected delay values to be different because of jitter. Actual value: ${delay1}`
+  )
+  assertLessOrEqual(
+    Math.abs(delay1 - delay2),
+    1_000,
+    `expected delay values to be within 1 second of each other. Actual values: ${delay1} <> ${delay2}`
+  )
 })

--- a/test/spark.js
+++ b/test/spark.js
@@ -421,7 +421,6 @@ test('calculateDelayBeforeNextTask() introduces random jitter for zero tasks in 
   )
 })
 
-// Should abort after hitting maxRequestDurationMs and set requestIdleTimeout = true
 test('fetchCAR triggers timeout after long retrieval', async () => {
   const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
   const fetch = async (_url, { signal }) => {


### PR DESCRIPTION
This PR adds a client-side max request duration timeout to prevent retrievals from lingering beyond a reasonable threshold, resolving issue #99.

- Adds `maxTimeout` tracking in `fetchCAR`
- Sets hard timeout (e.g. 90s) in addition to progress timeout (60s)
- Adds a test to ensure max timeout aborts stalled connections
