### PR TITLE
feat: add jitter to delay between tasks

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 export const SPARK_VERSION = '1.18.1'
 export const MAX_CAR_SIZE = 200 * 1024 * 1024 // 200 MB
 export const APPROX_ROUND_LENGTH_IN_MS = 20 * 60_000 // 20 minutes
+export const MAX_JITTER_BETWEEN_TASKS_IN_MS = 10_000 // 10 seconds
 export const RPC_URL = 'https://api.node.glif.io/'
 export const RPC_AUTH = 'KZLIUb9ejreYOm-mZFM3UNADE0ux6CrHjxnS2D2Qgb8='
 export const MINER_TO_PEERID_CONTRACT_ADDRESS = '0x14183aD016Ddc83D638425D6328009aa390339Ce' // Contract address on the Filecoin EVM

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -264,13 +264,13 @@ export default class Spark {
 /**
  * @param {object} args
  * @param {number} args.roundLengthInMs
- * @param {number} args.maxJitterInMs
+ * @param {number} [args.maxJitterInMs=0]
  * @param {number} args.maxTasksPerRound
  * @param {number} args.lastTaskDurationInMs
  */
 export function calculateDelayBeforeNextTask ({
   roundLengthInMs,
-  maxJitterInMs,
+  maxJitterInMs = 0,
   maxTasksPerRound,
   lastTaskDurationInMs
 }) {
@@ -279,7 +279,7 @@ export function calculateDelayBeforeNextTask ({
   const base = Math.min(delay, 60_000)
 
   // Introduce some jitter to avoid all clients querying cid.contact at the same time
-  const jitter = Math.round(Math.random() * (maxJitterInMs ?? 0))
+  const jitter = Math.round(Math.random() * maxJitterInMs)
 
   return base + jitter
 }

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -276,7 +276,7 @@ export function calculateDelayBeforeNextTask ({
 }) {
   const baseDelay = roundLengthInMs / maxTasksPerRound
   const delay = baseDelay - lastTaskDurationInMs
-  const base = Math.min(delay, 10_000)
+  const base = Math.min(delay, 60_000)
 
   // Introduce some jitter to avoid all clients querying cid.contact at the same time
   const jitter = Math.round(Math.random() * (maxJitterInMs ?? 0))

--- a/lib/spark.js
+++ b/lib/spark.js
@@ -1,7 +1,7 @@
 /* global Zinnia */
 
 import { ActivityState } from './activity-state.js'
-import { SPARK_VERSION, MAX_CAR_SIZE, APPROX_ROUND_LENGTH_IN_MS } from './constants.js'
+import { SPARK_VERSION, MAX_CAR_SIZE, APPROX_ROUND_LENGTH_IN_MS, MAX_JITTER_BETWEEN_TASKS_IN_MS } from './constants.js'
 import { queryTheIndex } from './ipni-client.js'
 import { assertOkResponse } from './http-assertions.js'
 import { getIndexProviderPeerId as defaultGetIndexProvider } from './miner-info.js'
@@ -235,6 +235,7 @@ export default class Spark {
       const duration = Date.now() - started
       const delay = calculateDelayBeforeNextTask({
         roundLengthInMs: APPROX_ROUND_LENGTH_IN_MS,
+        maxJitterInMs: MAX_JITTER_BETWEEN_TASKS_IN_MS,
         maxTasksPerRound: this.#tasker.maxTasksPerRound,
         lastTaskDurationInMs: duration
       })
@@ -263,17 +264,24 @@ export default class Spark {
 /**
  * @param {object} args
  * @param {number} args.roundLengthInMs
+ * @param {number} args.maxJitterInMs
  * @param {number} args.maxTasksPerRound
  * @param {number} args.lastTaskDurationInMs
  */
 export function calculateDelayBeforeNextTask ({
   roundLengthInMs,
+  maxJitterInMs,
   maxTasksPerRound,
   lastTaskDurationInMs
 }) {
   const baseDelay = roundLengthInMs / maxTasksPerRound
   const delay = baseDelay - lastTaskDurationInMs
-  return Math.min(delay, 60_000)
+  const base = Math.min(delay, 10_000)
+
+  // Introduce some jitter to avoid all clients querying cid.contact at the same time
+  const jitter = Math.round(Math.random() * (maxJitterInMs ?? 0))
+
+  return base + jitter
 }
 
 export function newStats () {

--- a/test/spark.js
+++ b/test/spark.js
@@ -2,7 +2,7 @@
 
 import Spark, { calculateDelayBeforeNextTask, newStats } from '../lib/spark.js'
 import { test } from 'zinnia:test'
-import { assertInstanceOf, assertEquals, assertArrayIncludes, assertNotEquals, assertLessOrEqual } from 'zinnia:assert'
+import { assertInstanceOf, assertEquals, assertArrayIncludes, assertNotEquals, assertLessOrEqual, assertGreaterOrEqual } from 'zinnia:assert'
 import { SPARK_VERSION } from '../lib/constants.js'
 
 const KNOWN_CID = 'bafkreih25dih6ug3xtj73vswccw423b56ilrwmnos4cbwhrceudopdp5sq'
@@ -378,6 +378,9 @@ test('calculateDelayBeforeNextTask() introduces random jitter', () => {
 
   const delay1 = getDelay()
   const delay2 = getDelay()
+
+  assertGreaterOrEqual(delay1, 7_000)
+  assertLessOrEqual(delay1, 7_000 + 1_000)
 
   assertNotEquals(
     delay1,


### PR DESCRIPTION
Introduce random jitter in the delay between subsequent tasks (retrieval checks).

The goal is to better spread out the requests from the network in the time, to avoid too many nodes hitting services like cid.contact at the same time.

Links:
- https://github.com/CheckerNetwork/spark-checker/issues/119

(I'll close the issue after I publish a new version of the spark checker.)
