### PR TITLE
fix: restrict publish files to only runtime essentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,15 @@
 {
   "name": "spark-checker",
+  "version": "0.1.0",
   "type": "module",
+  "files": [
+    "main.js",
+    "lib/",
+    "vendor/",
+    "README.md",
+    "LICENSE",
+    "deps.ts"
+  ],
   "scripts": {
     "lint": "eslint && prettier --check .",
     "lint:fix": "eslint --fix && prettier --write ."


### PR DESCRIPTION
This PR updates the `package.json` to use the `files` whitelist field, ensuring only essential runtime files are included when publishing to Zinnia via the `publish-zinnia-module-action`.

**Excluded:**
- Dev and CI files (`.github/`, `.prettierignore`, `test/`, `release.sh`, etc.)

**Included:**
- `main.js`, `lib/`, `vendor/`, `deps.ts`, `README.md`, `LICENSE`

Validated via `npm pack --dry-run` — total files reduced from 34 to 15, significantly reducing package size and improving runtime cleanliness.
Fixes #97 